### PR TITLE
[imSH-#20] 수식 최대화 정답 파일 추가

### DIFF
--- a/programmers/Level 2/수식 최대화/imSH.cpp
+++ b/programmers/Level 2/수식 최대화/imSH.cpp
@@ -1,0 +1,84 @@
+#include <string>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+typedef long long ll;
+
+// 순열 추출
+void permu(vector< vector<char> >& pri_op)
+{
+    vector<char> v = {'*', '+', '-'};
+    int i = 0;
+    do {
+        for (auto it = v.begin(); it != v.end(); ++it)
+            pri_op[i].push_back(*it);
+        i++;
+    } while (next_permutation(v.begin(), v.end()));
+}
+// 단순 계산
+ll calc(char op, ll a, ll b)
+{
+    if(op == '*') return a*b;
+    else if(op == '+') return a+b;
+    else return a-b;
+}
+// 우선 순위를 반영한 최대 값 반환
+ll func(vector<char> pri, vector<ll> num, vector<char> op)
+{
+    ll total = 0;
+    int idx = 0;
+    while(!op.empty())
+    {
+        // 현재 우선 순위에 해당하는 연산자가 있다면
+        while(find(op.begin(), op.end(), pri[idx]) != op.end())
+        {
+            // 우선 순위에 해당하는 연산자의 인덱스 값
+            int op_idx = find(op.begin(), op.end(), pri[idx]) - op.begin();
+            // 연산자 왼쪽 수 = 연산자 양 옆의 수를 계산한 값 (대입)
+            num[op_idx] = calc(pri[idx], num[op_idx], num[op_idx+1]);
+            // 사용한 연산자 삭제
+            op.erase(op.begin() + op_idx);
+            // 사용한 숫자 중 오른쪽 수 삭제
+            num.erase(num.begin() + op_idx+1);
+        }
+        idx++;
+    }
+  	// 반드시 0 번째 요소가 남게 되므로(피연산자 수 + 1 == 연산자 수) 이를 최종 값으로 반환
+    return num[0] > 0 ? num[0] : -num[0];
+}
+
+ll solution(string expression) 
+{
+    ll answer = 0;
+
+    vector<ll> num; // 피연산자 배열
+    vector<char> op; // 연산자 배열
+    vector < vector<char> > pri_op(6); // 연산자 순열
+    permu(pri_op); // 연산자 순열화
+    string temp_num;
+
+    for(auto s : expression) // 연산자, 피연산자 배열화
+    {
+        if('0' <= s && s <= '9') 
+        {
+            temp_num += s;
+        }
+        else
+        {
+            num.push_back(stoi(temp_num));
+            op.push_back(s);
+            temp_num = "";
+        }
+    }
+    num.push_back(stoi(temp_num));
+
+    for(int i=0; i<6; i++)
+    {
+        auto temp = func(pri_op[i], num, op);
+        if(answer < temp) answer = temp;
+    }
+
+    return answer;
+}

--- a/programmers/Level 2/수식 최대화/imSH.cpp
+++ b/programmers/Level 2/수식 최대화/imSH.cpp
@@ -45,7 +45,7 @@ ll func(vector<char> pri, vector<ll> num, vector<char> op)
         }
         idx++;
     }
-  	// 반드시 0 번째 요소가 남게 되므로(피연산자 수 + 1 == 연산자 수) 이를 최종 값으로 반환
+  	// 반드시 0 번째 요소가 남게 되므로(피연산자 수 - 1 == 연산자 수) 이를 최종 값으로 반환
     return num[0] > 0 ? num[0] : -num[0];
 }
 


### PR DESCRIPTION
issue #20 

## 풀이 방법

- ### 연산자 순열

> 연산자의 종류는 `+`,`-`,`*` 3 개이다. 중복이 없는 3개의 원소로 만들 수 있는 순열은 $3!$ 의 개수와 같다. 단순히 6개의 문자열 순서를 일일이 나열해도 되지만 조금더 합리적인 방법으로 접근이 가능하다. `Permutation` 즉 순열을 사용하는 것이다. 이를 직접 구현하는 것도 가능하겠지만 문제를 풀기 위해 더 큰 문제를 푸는 기분이 들어 `<algorithm>` 헤더를 통해 `next_permutation()` 함수를 가져와 사용한다. 이 함수는 들어온 `vector` 의 순열을 탐색하여 접근이 가능하게 해준다.  
  

- ### 문자열 내 연산자 및 피연산자 추출

> `"50*6-3*2"` 와 같은 문자열이 주어진다면 우리는 이를 `{50, 6, 3, 2}` 와 `{*, -, *}` 로 분리 하였을 때 편할 것 같다는 느낌이 들었다. 연산자, 피연산자의 인덱스를 유지한 채로 분리할 시 `n` 번째 피연산자와 `n + 1` 번째 피 연산자는 `n` 번째 연산자를 사용하여 계산할 수 있다.  

- ### 우선 순위를 이용한 연산

> 우선 순위에 해당하는 연산자를 찾아 앞 추출 부분에서 언급 되었던 계산 방식을 사용한다. `n` , `n+1` 번째의 피연산자가 `n` 번째 연산자를 통해 계산 되었다면 더 이상 `n`, `n+1` 의 피연산자는 필요하지 않고 그 둘을 통해 계산한 새로운 피연산자( `new = n + n+1`)만 필요해진다. 이 새로운 피연산자가 기존 피연산자의 자리를 대체하고, 사용되었던 연산자는 연산자 배열에서 삭제를 반복한다면 원하는 결과를 얻을 수 있을 것이다.  
